### PR TITLE
chore: rename useDataLayer to useAnalytics

### DIFF
--- a/examples/pixel/README.md
+++ b/examples/pixel/README.md
@@ -1,6 +1,10 @@
 # Bloomreach - Pixel instrumentation example
 
-This example demonstrates how to instrument pixel across a simple storefront. See `config.js` file to configure it to run for your account and catalog
+This example demonstrates how to instrument pixel across a simple storefront.
+
+- See `src/config.js` file to configure it to run for your account and catalog
+- See `src/hooks/useAnalytics.js` file to see how the pixel events are formatted
+- Search for [trackEvent](/search?q=repo%3Abloomreach%2Fweb-code-samples+path%3A%2F%5Eexamples%5C%2Fpixel%5C%2Fsrc%5C%2F%2F+trackEvent&type=code) to see how the pixel events are instrumented across the sourcecode
 
 ## How to use
 

--- a/examples/pixel/README.md
+++ b/examples/pixel/README.md
@@ -4,7 +4,7 @@ This example demonstrates how to instrument pixel across a simple storefront.
 
 - See `src/config.js` file to configure it to run for your account and catalog
 - See `src/hooks/useAnalytics.js` file to see how the pixel events are formatted
-- Search for [trackEvent](/search?q=repo%3Abloomreach%2Fweb-code-samples+path%3A%2F%5Eexamples%5C%2Fpixel%5C%2Fsrc%5C%2F%2F+trackEvent&type=code) to see how the pixel events are instrumented across the sourcecode
+- Search for the term `trackEvent` to see how the pixel events are instrumented across the sourcecode
 
 ## How to use
 

--- a/examples/pixel/README.md
+++ b/examples/pixel/README.md
@@ -5,6 +5,7 @@ This example demonstrates how to instrument pixel across a simple storefront.
 - See `src/config.js` file to configure it to run for your account and catalog
 - See `src/hooks/useAnalytics.js` file to see how the pixel events are formatted
 - Search for the term `trackEvent` to see how the pixel events are instrumented across the sourcecode
+- Note: On codesandbox, because of how the preview is rendered in the iframe, the pixel script is not able to set the `_br_uid_2` cookie on the right domain, so you will not see the cookie sent in the pixel events. For the cookie to be set and sent in the pixel events, open the codesandbox preview in a new tab or run the example locally
 
 ## How to use
 

--- a/examples/pixel/src/app/DeveloperToolbar.jsx
+++ b/examples/pixel/src/app/DeveloperToolbar.jsx
@@ -2,11 +2,11 @@ import Link from 'next/link';
 import { ToggleField } from '@bloomreach/react-banana-ui';
 import { account_id, account_name } from '../config';
 import { useDeveloperTools } from '../hooks/useDeveloperTools';
-import useDataLayer from '../hooks/useDataLayer';
+import useAnalytics from '../hooks/useAnalytics';
 
 export function DeveloperToolbar() {
   const { showJson, setShowJson } = useDeveloperTools();
-  const { eventsCount } = useDataLayer();
+  const { eventsCount } = useAnalytics();
 
   return (
     <div className="bg-[#002840]">

--- a/examples/pixel/src/app/cart/page.jsx
+++ b/examples/pixel/src/app/cart/page.jsx
@@ -8,14 +8,14 @@ import { useEffect, useState } from 'react';
 import useCart from '../../hooks/useCart';
 import useRecommendationsApi from '../../hooks/useRecommendationsApi';
 import { similar_products_widget_id } from '../../config';
-import { config } from '../../utils';
 import { ProductsCarouselWidget } from '../../components/ProductsCarouselWidget';
+import { CONFIG } from '../../constants';
 
 export default function Page() {
   const router = useRouter();
   const { cart, incrementItem, decrementItem, removeItem, cartCount, cartTotal } = useCart();
   const [recOptions, setRecOptions] = useState({});
-  const { data: similarProducts } = useRecommendationsApi(similar_products_widget_id, config, recOptions);
+  const { data: similarProducts } = useRecommendationsApi(similar_products_widget_id, CONFIG, recOptions);
   const [ref, isIntersecting] = useIntersectionObserver({
     threshold: 0,
     root: null,

--- a/examples/pixel/src/app/categories/[id]/page.jsx
+++ b/examples/pixel/src/app/categories/[id]/page.jsx
@@ -10,7 +10,7 @@ import { CategoryNav } from './category-nav';
 import { Price } from '../../../components/Price';
 
 import { buildCategoryHierarchy, getActiveCategories } from './utils';
-import useDataLayer from '../../../hooks/useDataLayer';
+import useAnalytics from '../../../hooks/useAnalytics';
 import { useDeveloperTools } from '../../../hooks/useDeveloperTools';
 import useSearchApi from '../../../hooks/useSearchApi';
 import { config } from '../../../utils';
@@ -21,7 +21,7 @@ export default function Page({ params, searchParams }) {
   const router = useRouter();
   const pathname = usePathname();
   const { showJson } = useDeveloperTools();
-  const dataLayer = useDataLayer();
+  const { trackEvent } = useAnalytics();
   const [categories, setCategories] = useState([]);
   const [categoryHierarchy, setCategoryHierarchy] = useState([]);
   const [categoryProductsOptions, setCategoryProductsOptions] = useState({});
@@ -59,7 +59,7 @@ export default function Page({ params, searchParams }) {
 
   useEffect(() => {
     if (categories.length > 0 && data) {
-      dataLayer.push({
+      trackEvent({
         event: 'view_category',
         cat_id: categoryId,
         cat_crumb: activeCategories.join('|'),

--- a/examples/pixel/src/app/categories/[id]/page.jsx
+++ b/examples/pixel/src/app/categories/[id]/page.jsx
@@ -13,7 +13,7 @@ import { buildCategoryHierarchy, getActiveCategories } from './utils';
 import useAnalytics from '../../../hooks/useAnalytics';
 import { useDeveloperTools } from '../../../hooks/useDeveloperTools';
 import useSearchApi from '../../../hooks/useSearchApi';
-import { config } from '../../../utils';
+import { CONFIG } from '../../../constants';
 
 export default function Page({ params, searchParams }) {
   const { id: categoryId } = params;
@@ -27,8 +27,8 @@ export default function Page({ params, searchParams }) {
   const [categoryProductsOptions, setCategoryProductsOptions] = useState({});
   const [categoriesListOptions] = useState({ q: '*' });
 
-  const { loading, error, data } = useSearchApi('category', config, categoryProductsOptions);
-  const { loading: cLoading, error: cError, data: cData } = useSearchApi('keyword', config, categoriesListOptions);
+  const { loading, error, data } = useSearchApi('category', CONFIG, categoryProductsOptions);
+  const { loading: cLoading, error: cError, data: cData } = useSearchApi('keyword', CONFIG, categoriesListOptions);
 
   const activeCategories = getActiveCategories(categories, categoryId);
 

--- a/examples/pixel/src/app/checkout/page.jsx
+++ b/examples/pixel/src/app/checkout/page.jsx
@@ -3,15 +3,15 @@
 import { useState } from 'react';
 import { Button } from '@bloomreach/react-banana-ui';
 import useCart from '../../hooks/useCart';
-import useDataLayer from '../../hooks/useDataLayer';
+import useAnalytics from '../../hooks/useAnalytics';
 
 export default function Page() {
   const { cart, cartCount, cartTotal, clearCart } = useCart();
   const [isPurchaseComplete, setIsPurchaseComplete] = useState(false);
-  const dataLayer = useDataLayer();
+  const { trackEvent } = useAnalytics();
 
   const onConversion = () => {
-    dataLayer.push({
+    trackEvent({
       event: 'view_conversion',
       cartTotal,
       orderId: Date.now(),

--- a/examples/pixel/src/app/events/page.jsx
+++ b/examples/pixel/src/app/events/page.jsx
@@ -1,7 +1,7 @@
 'use client';
 
 import JsonView from '@uiw/react-json-view';
-import {Button, ExternalLinkIcon} from '@bloomreach/react-banana-ui';
+import { Button, ExternalLinkIcon } from '@bloomreach/react-banana-ui';
 import useAnalytics from '../../hooks/useAnalytics';
 
 export default function Page() {

--- a/examples/pixel/src/app/events/page.jsx
+++ b/examples/pixel/src/app/events/page.jsx
@@ -2,10 +2,10 @@
 
 import JsonView from '@uiw/react-json-view';
 import {Button, ExternalLinkIcon} from '@bloomreach/react-banana-ui';
-import useDataLayer from '../../hooks/useDataLayer';
+import useAnalytics from '../../hooks/useAnalytics';
 
 export default function Page() {
-  const { events, clearEvents } = useDataLayer();
+  const { events, clearEvents } = useAnalytics();
 
   return (
     <div>

--- a/examples/pixel/src/app/page.jsx
+++ b/examples/pixel/src/app/page.jsx
@@ -6,7 +6,7 @@ import JsonView from '@uiw/react-json-view';
 import { Price } from '../components/Price';
 import { useDeveloperTools } from '../hooks/useDeveloperTools';
 import useSearchApi from '../hooks/useSearchApi';
-import { config } from '../utils';
+import { CONFIG } from '../constants';
 
 function getRandomCategories(data) {
   const categories = data.facet_counts.facets.filter((facet) => facet.name === 'category');
@@ -26,7 +26,7 @@ export default function Home() {
     q: '*',
     rows: 12,
   });
-  const { loading, error, data } = useSearchApi('bestseller', config, options);
+  const { loading, error, data } = useSearchApi('bestseller', CONFIG, options);
 
   useEffect(() => {
     if (data) {

--- a/examples/pixel/src/app/products/[id]/page.jsx
+++ b/examples/pixel/src/app/products/[id]/page.jsx
@@ -10,9 +10,9 @@ import useAnalytics from '../../../hooks/useAnalytics';
 import { useDeveloperTools } from '../../../hooks/useDeveloperTools';
 import { ProductsCarouselWidget } from '../../../components/ProductsCarouselWidget';
 import useSearchApi from '../../../hooks/useSearchApi';
-import { config } from '../../../utils';
 import useRecommendationsApi from '../../../hooks/useRecommendationsApi';
 import { similar_products_widget_id } from '../../../config';
+import { CONFIG } from '../../../constants';
 
 export default function Page({ params }) {
   const { id: pid } = params;
@@ -21,8 +21,8 @@ export default function Page({ params }) {
   const { trackEvent } = useAnalytics();
   const [options, setOptions] = useState({});
   const [recOptions, setRecOptions] = useState({});
-  const { loading, error, data } = useSearchApi('keyword', config, options);
-  const { data: similarProducts } = useRecommendationsApi(similar_products_widget_id, config, recOptions);
+  const { loading, error, data } = useSearchApi('keyword', CONFIG, options);
+  const { data: similarProducts } = useRecommendationsApi(similar_products_widget_id, CONFIG, recOptions);
   const [ref, isIntersecting] = useIntersectionObserver({
     threshold: 0,
     root: null,

--- a/examples/pixel/src/app/products/[id]/page.jsx
+++ b/examples/pixel/src/app/products/[id]/page.jsx
@@ -6,7 +6,7 @@ import { Button } from '@bloomreach/react-banana-ui';
 import { useIntersectionObserver } from 'usehooks-ts';
 import { Price } from '../../../components/Price';
 import useCart from '../../../hooks/useCart';
-import useDataLayer from '../../../hooks/useDataLayer';
+import useAnalytics from '../../../hooks/useAnalytics';
 import { useDeveloperTools } from '../../../hooks/useDeveloperTools';
 import { ProductsCarouselWidget } from '../../../components/ProductsCarouselWidget';
 import useSearchApi from '../../../hooks/useSearchApi';
@@ -18,7 +18,7 @@ export default function Page({ params }) {
   const { id: pid } = params;
   const { showJson } = useDeveloperTools();
   const { addItem } = useCart();
-  const dataLayer = useDataLayer();
+  const { trackEvent } = useAnalytics();
   const [options, setOptions] = useState({});
   const [recOptions, setRecOptions] = useState({});
   const { loading, error, data } = useSearchApi('keyword', config, options);
@@ -52,7 +52,7 @@ export default function Page({ params }) {
     if (!product) {
       return;
     }
-    dataLayer.push({
+    trackEvent({
       event: 'view_product',
       pid: product.pid,
       title: product.title,
@@ -60,18 +60,18 @@ export default function Page({ params }) {
     });
   }, [product, sku]);
 
-  const addToCart = (product) => {
+  const addToCart = (item) => {
     addItem({
-      id: product.pid,
+      id: item.pid,
       sku,
-      image: product.thumb_image,
-      title: product.title,
+      image: item.thumb_image,
+      title: item.title,
       subtitle: '',
-      price: product.salePrice || product.price,
+      price: item.salePrice || item.price,
     });
-    dataLayer.push({
+    trackEvent({
       event: 'event_addToCart',
-      pid: product.pid,
+      pid: item.pid,
       sku,
     });
   };

--- a/examples/pixel/src/app/products/page.jsx
+++ b/examples/pixel/src/app/products/page.jsx
@@ -10,13 +10,8 @@ import { Price } from '../../components/Price';
 import useAnalytics from '../../hooks/useAnalytics';
 import { useDeveloperTools } from '../../hooks/useDeveloperTools';
 import useSearchApi from '../../hooks/useSearchApi';
-import { account_id, auth_key, domain_key } from '../../config';
+import { CONFIG } from '../../constants';
 
-const config = {
-  account_id,
-  auth_key,
-  domain_key,
-};
 export default function Page({ searchParams }) {
   const { showJson } = useDeveloperTools();
   const router = useRouter();
@@ -24,7 +19,7 @@ export default function Page({ searchParams }) {
   const { trackEvent } = useAnalytics();
   const [options, setOptions] = useState({});
 
-  const { loading, error, data } = useSearchApi('keyword', config, options);
+  const { loading, error, data } = useSearchApi('keyword', CONFIG, options);
 
   useEffect(() => {
     setOptions({

--- a/examples/pixel/src/app/products/page.jsx
+++ b/examples/pixel/src/app/products/page.jsx
@@ -7,7 +7,7 @@ import Highlighter from 'react-highlight-words';
 import JsonView from '@uiw/react-json-view';
 import { Pagination } from '@bloomreach/react-banana-ui';
 import { Price } from '../../components/Price';
-import useDataLayer from '../../hooks/useDataLayer';
+import useAnalytics from '../../hooks/useAnalytics';
 import { useDeveloperTools } from '../../hooks/useDeveloperTools';
 import useSearchApi from '../../hooks/useSearchApi';
 import { account_id, auth_key, domain_key } from '../../config';
@@ -21,7 +21,7 @@ export default function Page({ searchParams }) {
   const { showJson } = useDeveloperTools();
   const router = useRouter();
   const { q = '', sort = '', page = 0, rows = 12 } = searchParams;
-  const dataLayer = useDataLayer();
+  const { trackEvent } = useAnalytics();
   const [options, setOptions] = useState({});
 
   const { loading, error, data } = useSearchApi('keyword', config, options);
@@ -41,7 +41,7 @@ export default function Page({ searchParams }) {
     if (!data) {
       return;
     }
-    dataLayer.push({
+    trackEvent({
       event: 'view_search',
       query: q,
     });

--- a/examples/pixel/src/app/user/page.jsx
+++ b/examples/pixel/src/app/user/page.jsx
@@ -3,11 +3,11 @@
 import JsonView from '@uiw/react-json-view';
 import { useCookies } from 'react-cookie';
 import { Button, InputField } from '@bloomreach/react-banana-ui';
-import useDataLayer from '../../hooks/useDataLayer';
+import useAnalytics from '../../hooks/useAnalytics';
 import { BR_COOKIE } from '../../constants';
 
 export default function Page() {
-  const { userId, setUserId } = useDataLayer();
+  const { userId, setUserId } = useAnalytics();
   const [cookies, setCookie, removeCookie] = useCookies([BR_COOKIE]);
 
   const clearCookie = () => {

--- a/examples/pixel/src/components/ProductsCarouselWidget.jsx
+++ b/examples/pixel/src/components/ProductsCarouselWidget.jsx
@@ -3,15 +3,15 @@ import Link from 'next/link';
 import { InfoIcon, Tooltip } from '@bloomreach/react-banana-ui';
 import JsonView from '@uiw/react-json-view';
 import { Price } from './Price';
-import useDataLayer from '../hooks/useDataLayer';
+import useAnalytics from '../hooks/useAnalytics';
 import { useDeveloperTools } from '../hooks/useDeveloperTools';
 
 export function ProductsCarouselWidget({ title = 'Similar products', data }) {
   const { showJson } = useDeveloperTools();
-  const dataLayer = useDataLayer();
+  const { trackEvent } = useAnalytics();
 
   function sendClickEvent(id) {
-    dataLayer.push({
+    trackEvent({
       event: 'event_widgetClick',
       widgetId: data.metadata.widget.id,
       widgetType: data.metadata.widget.type,
@@ -21,13 +21,13 @@ export function ProductsCarouselWidget({ title = 'Similar products', data }) {
   }
 
   useEffect(() => {
-    dataLayer.push({
+    trackEvent({
       event: 'event_widgetView',
       widgetId: data.metadata.widget.id,
       widgetType: data.metadata.widget.type,
       widgetRequestId: data.metadata.widget.rid,
     });
-  }, []);
+  }, [data]);
 
   if (!data) {
     return null;

--- a/examples/pixel/src/components/SearchBar.jsx
+++ b/examples/pixel/src/components/SearchBar.jsx
@@ -5,14 +5,14 @@ import Highlighter from 'react-highlight-words';
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
-import useDataLayer from '../hooks/useDataLayer';
+import useAnalytics from '../hooks/useAnalytics';
 import useAutosuggestApi from '../hooks/useAutosuggestApi';
 import { config } from '../utils';
 
 export function SearchBar() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const dataLayer = useDataLayer();
+  const { trackEvent } = useAnalytics();
   const [options, setOptions] = useState({});
   const [query, setQuery] = useState('');
   const [isInputActive, setIsInputActive] = useState(false);
@@ -29,7 +29,7 @@ export function SearchBar() {
 
   const handleSubmit = (e) => {
     e && e.preventDefault();
-    dataLayer.push({
+    trackEvent({
       event: 'event_search',
       query,
     });
@@ -39,7 +39,7 @@ export function SearchBar() {
 
   const handleQuerySearch = (term) => {
     setIsHoveringResults(false);
-    dataLayer.push({
+   trackEvent({
       event: 'event_suggest',
       userQuery: query,
       query: term,

--- a/examples/pixel/src/components/SearchBar.jsx
+++ b/examples/pixel/src/components/SearchBar.jsx
@@ -7,7 +7,7 @@ import { useEffect, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import useAnalytics from '../hooks/useAnalytics';
 import useAutosuggestApi from '../hooks/useAutosuggestApi';
-import { config } from '../utils';
+import { CONFIG } from '../constants';
 
 export function SearchBar() {
   const router = useRouter();
@@ -17,7 +17,7 @@ export function SearchBar() {
   const [query, setQuery] = useState('');
   const [isInputActive, setIsInputActive] = useState(false);
   const [isHoveringResults, setIsHoveringResults] = useState(false);
-  const { loading, error, data } = useAutosuggestApi(config, options);
+  const { loading, error, data } = useAutosuggestApi(CONFIG, options);
 
   useEffect(() => {
     setQuery(searchParams.get('q') || '');

--- a/examples/pixel/src/constants.js
+++ b/examples/pixel/src/constants.js
@@ -1,1 +1,8 @@
+import { account_id, auth_key, domain_key } from './config';
+
 export const BR_COOKIE = '_br_uid_2';
+export const CONFIG = {
+  account_id,
+  domain_key,
+  auth_key,
+};

--- a/examples/pixel/src/hooks/useAutosuggestApi.js
+++ b/examples/pixel/src/hooks/useAutosuggestApi.js
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { autoSuggest } from '@bloomreach/discovery-web-sdk';
 import { useCookies } from 'react-cookie';
 import { BR_COOKIE } from '../constants';
+import { catalog_views } from '../config';
 
 function useAutosuggestApi(config, options) {
   const [data, setData] = useState(null);
@@ -23,6 +24,7 @@ function useAutosuggestApi(config, options) {
         ref_url: window.location.href,
         request_id: Date.now(),
         q: options.q,
+        catalog_views,
       },
     ).then((res) => {
       setLoading(false);

--- a/examples/pixel/src/utils.js
+++ b/examples/pixel/src/utils.js
@@ -1,8 +1,0 @@
-import { account_id, auth_key, catalog_views, domain_key } from './config';
-
-export const config = {
-  account_id,
-  domain_key,
-  auth_key,
-  catalog_views,
-};


### PR DESCRIPTION
To avoid confusion with the `dataLayer.push` event used for the tag manager implementation